### PR TITLE
Make the Lazy basic implementation much faster...

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,4 @@
 {
-    "version": "2.0.0",
     "summary": "Basic primitives for working with laziness",
     "repository": "http://github.com/elm-lang/lazy.git",
     "license": "BSD3",

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -25,8 +25,9 @@ import Native.Lazy
 
 
 {-| A wrapper around a value that will be lazily evaluated. -}
-type Lazy a =
-  Lazy (() -> a)
+type Lazy a
+  = Evaluated a
+  | Unevaluated (() -> a)
 
 
 {-| Delay the evaluation of a value until later. For example, maybe we will
@@ -41,7 +42,7 @@ Now we only pay for `lazySum` if we actually need it.
 -}
 lazy : (() -> a) -> Lazy a
 lazy thunk =
-  Lazy (Native.Lazy.memoize thunk)
+  Unevaluated thunk
 
 
 {-| Force the evaluation of a lazy value. This means we only pay for the
@@ -61,8 +62,10 @@ the first one, but all the rest are very cheap, basically just looking up a
 value in memory.
 -}
 force : Lazy a -> a
-force (Lazy thunk) =
-  thunk ()
+force lzy =
+  case lzy of
+    Evaluated a -> a
+    Unevaluated _ -> Native.Lazy.memoize lzy
 
 
 

--- a/src/Native/Lazy.js
+++ b/src/Native/Lazy.js
@@ -1,16 +1,14 @@
 var _elm_lang$lazy$Native_Lazy = function() {
 
-function memoize(thunk)
-{
-    var value;
-    var isForced = false;
-    return function(tuple0) {
-        if (!isForced) {
-            value = thunk(tuple0);
-            isForced = true;
-        }
-        return value;
-    };
+// mutates `lzy` Unevaluated thunk into Evaluated value, returning value.
+function memoize(lzy) {
+    if (lzy.ctor === 'Evaluating')
+        throw Error("Lazy.memoize:  recursive evaluation error!!!");
+    lzy.ctor = 'Evaluating';
+    var v = lzy._0(lzy); // dummy placeholder arg
+    lzy.ctor = 'Evaluated';
+    lzy._0 = v;
+    return v;
 }
 
 return {


### PR DESCRIPTION
The current JavaScript Native "memoize" function works by returning a nested forcer function when the outer "memoize" function is called to initialize the representation of the `Lazy' type with the thunk argument so that the evaluated data will later be stored as a local variable within the outer "memoize" function's scope when the returned inner forcer function is called.  This scheme of bulding a new nested inner function "on-the-fly" every time a new `Lazy' is initialized is very costly in execution time when run on many current main stream browsers such as Chome 55:  http://jsperf.com/iifes-vs-nested-functions/4.

In order to speed this up, the generic `Lazy' type is changed to an Elm Tagged Union so that the `force' function can call the Native JS "memoize" function on that type without needing to create any new
functions.

As an added benefit, the Native JS "memoize" function can check for recursive evaluation of the thunk and throw an error early rather than waiting for a stack overflow on the infinite loop with very little cost
in execution time.

This change affects the `Lazy a' generic type, the `lazy' type constructor function, and the `force' function as well as the Native JS "memoize" function; howeverk it makes no changes to the API of the Lazy
library module.

This speed can be verified by timing the enumeration of the following simple natural number lazy list sequence producing function as per the following code:

    type List a = Node a (Lazy (List a))

    nat32s : () -> List Int
    nat32s() =
      let nat32si n =
        Node n << lazy <| \() -> nat32si (n + 1)
      in nat32si 0
    
    nthnat32 : Int -> String
    nthnat32 n =
      let nthnati n nts =
        case nts of
          Node _ tl ->
            if n <= 0 then 
              case nts of
                Node hd _ -> toString hd else
            nthnati (n - 1) (force tl)
      in nthnati n (nat32s())

When run using the proposed changes compared to with the original code, running `nthnat32 999999' (one million iterations), this test code is faster by about six times for Chrome 55 Stable, about four times for Firefox 51 Stable, and about two times faster for Microsoft Edge 38.14393.0.0, with all three browsers having about the same overall exectution time after the change (Chrome was formerly considerably slower than the others).

The version number has only been upped to 2.1.0 although this is a very significant change as there are no changes to the API.